### PR TITLE
プレビュー機能をつけよう

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -4,10 +4,10 @@
 // that code so it'll be compiled.
 
 require("@rails/ujs").start()
-require("turbolinks").start()
+// require("turbolinks").start()
 require("@rails/activestorage").start()
 require("channels")
-
+require('./preview')
 // Uncomment to copy all static images under ../images to the output folder and reference
 // them with the image_pack_tag helper in views (e.g <%= image_pack_tag 'rails.png' %>)
 // or the `imagePath` JavaScript helper below.

--- a/app/javascript/packs/preview.js
+++ b/app/javascript/packs/preview.js
@@ -1,0 +1,3 @@
+document.addEventListener('DOMContentLoaded', function(){
+  console.log(123);
+});

--- a/app/javascript/packs/preview.js
+++ b/app/javascript/packs/preview.js
@@ -1,5 +1,5 @@
 document.addEventListener('DOMContentLoaded', function(){
   document.querySelector('#message_image'),addEventListener('change', function(e){
-    console.log(e);
+    const preview = e.target.files[0];
   });
 });

--- a/app/javascript/packs/preview.js
+++ b/app/javascript/packs/preview.js
@@ -1,5 +1,10 @@
 document.addEventListener('DOMContentLoaded', function(){
   document.querySelector('#message_image'),addEventListener('change', function(e){
+    const image_content = document.querySelector('img');
+    if (image_content){
+      image_content.remove();
+    };
+
     const preview = e.target.files[0];
     const blob = window.URL.createObjectURL(preview);
     const html = `<img src="${blob}">`;

--- a/app/javascript/packs/preview.js
+++ b/app/javascript/packs/preview.js
@@ -1,5 +1,5 @@
 document.addEventListener('DOMContentLoaded', function(){
   document.querySelector('#message_image'),addEventListener('change', function(e){
-    console.log(123);
+    console.log(e);
   });
 });

--- a/app/javascript/packs/preview.js
+++ b/app/javascript/packs/preview.js
@@ -2,5 +2,7 @@ document.addEventListener('DOMContentLoaded', function(){
   document.querySelector('#message_image'),addEventListener('change', function(e){
     const preview = e.target.files[0];
     const blob = window.URL.createObjectURL(preview);
+    const html = `<img src="${blob}">`;
+    document.querySelector('form').insertAdjacentHTML('afterend' , html);
   });
 });

--- a/app/javascript/packs/preview.js
+++ b/app/javascript/packs/preview.js
@@ -1,5 +1,6 @@
 document.addEventListener('DOMContentLoaded', function(){
   document.querySelector('#message_image'),addEventListener('change', function(e){
     const preview = e.target.files[0];
+    const blob = window.URL.createObjectURL(preview);
   });
 });

--- a/app/javascript/packs/preview.js
+++ b/app/javascript/packs/preview.js
@@ -1,3 +1,5 @@
 document.addEventListener('DOMContentLoaded', function(){
-  console.log(123);
+  document.querySelector('#message_image'),addEventListener('change', function(e){
+    console.log(123);
+  });
 });


### PR DESCRIPTION
# 概要
追加カリキュラムである「プレビュー機能をつけよう」のQC
# 作業内容
## 事前準備
**実行したコマンド**
```bash
% cd projects
% git clone https://github.com/we-b/mini_image_app.git
% cd mini_image_app
% rm -rf .git
% rails db:create
% rails db:migrate
```
**作成したファイル**
`app/javascript/packs/preview.js`

### 作業箇所
- ミニアプリをローカル環境に準備しましょう
- preview.jsを作成しましょう
- application.jsを編集しましょう
- ページが読み込まれたときに動作する関数を定義しましょう

## プレビュー機能の実装
**実行したコマンド**
なし

**作成したファイル**
なし

### 新しい知識
- e.target.files[0]
- window.URL.createObjectURL

### 作業箇所
- input要素で値の変化が起こったときに呼び出される関数を定義しましょう
- inputのなかにある画像を取得しましょう
- 画像情報を変数に格納しましょう
- 取得した画像情報のURLを生成しましょう。
- 生成したsrcを用いてプレビューを挿入しましょう
- 表示されている画像を編集しましょう

## 実装結果
### ページが読み込まれたときに動作する関数を定義しましょう
**ディベロッパツールのconsoleに「123」と表示できていれば成功**

[![Image from Gyazo](https://i.gyazo.com/0fddfe433089e029bed65e027400498c.png)](https://gyazo.com/0fddfe433089e029bed65e027400498c)

### input要素で値の変化が起こったときに呼び出される関数を定義しましょう
**file_fieldsをクリックして適当な画像を選択し、以下のように123と表示できていれば成功**

[![Image from Gyazo](https://i.gyazo.com/6077eadfad448571d349fd0ab545be2e.gif)](https://gyazo.com/6077eadfad448571d349fd0ab545be2e)

### 生成したsrcを用いてプレビューを挿入しましょう

[![Image from Gyazo](https://i.gyazo.com/c08f1d5ec4270c2fde04c1494cc2da1b.gif)](https://gyazo.com/c08f1d5ec4270c2fde04c1494cc2da1b)