### PR TITLE
複数枚画像投稿を実装しよう

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -31,7 +31,7 @@ class MessagesController < ApplicationController
 
   private
   def message_params
-    params.require(:message).permit(:content, :image)
+    params.require(:message).permit(:content, images: [])
   end
 
   def set_message

--- a/app/javascript/packs/preview.js
+++ b/app/javascript/packs/preview.js
@@ -1,15 +1,26 @@
-document.addEventListener('DOMContentLoaded', function(){
-  document.querySelector('#message_image'),addEventListener('change', function(e){
-  const image_content = document.querySelector('img');
-    if (image_content){
-      image_content.remove();
-    };
+document.addEventListener('DOMContentLoaded', function (){
+  const clickLabel = function(){
+    const inputAll = document.getElementsByName('message[images][]');
+    const inputLast = inputAll[inputAll.length -1];
+    const inputId = inputLast.getAttribute('id');
+    console.log(inputId);
+    document.getElementById('click-upload').setAttribute('for', inputId);
+  };
 
-    const preview = e.target.files[0];
-    const blob = window.URL.createObjectURL(preview);
-    const html = `<img src="${blob}">`;
-    const inputHTML = `<input type='file' name='message[images][]' id="message_images">`;
-    document.querySelector('form').insertAdjacentHTML('afterend' , html);
-    document.getElementById('new_message').insertAdjacentHTML('beforeend', inputHTML);
+  const changeInput = () => {
+    document.getElementById('message_images').addEventListener('change', function(e){
+      const file = e.target.files[0];
+      const blob = window.URL.createObjectURL(file);
+      const inputAll = document.getElementsByName('message[images][]');
+      const blobHTML = `<img src="${blob}">`;
+      const inputHTML = `<input type='file' name='message[images][]' id="message_images">`;
+      document.getElementById('new_message').insertAdjacentHTML('beforebegin', blobHTML);
+      document.getElementById('new_message').insertAdjacentHTML('beforeend', inputHTML);
+    });
+  };
+
+  document.getElementById('click-upload').addEventListener('click', function(){
+    clickLabel();
+    changeInput();
   });
 });

--- a/app/javascript/packs/preview.js
+++ b/app/javascript/packs/preview.js
@@ -7,13 +7,13 @@ document.addEventListener('DOMContentLoaded', function (){
     document.getElementById('click-upload').setAttribute('for', inputId);
   };
 
-  const changeInput = () => {
-    document.getElementById('message_images').addEventListener('change', function(e){
+  const changeInput = (inputArrayLast) => {
+    inputArrayLast.addEventListener('change', function(e){
       const file = e.target.files[0];
       const blob = window.URL.createObjectURL(file);
-      const inputAll = document.getElementsByName('message[images][]');
       const blobHTML = `<img src="${blob}">`;
-      const inputHTML = `<input type='file' name='message[images][]' id="message_images">`;
+      const i = e.target.getAttribute('data-index').to_i +1;
+      const inputHTML = `<input type='file' name='message[images][]' id="message_images_${i}" data-index="${i}">`;
       document.getElementById('new_message').insertAdjacentHTML('beforebegin', blobHTML);
       document.getElementById('new_message').insertAdjacentHTML('beforeend', inputHTML);
     });

--- a/app/javascript/packs/preview.js
+++ b/app/javascript/packs/preview.js
@@ -1,6 +1,6 @@
 document.addEventListener('DOMContentLoaded', function(){
   document.querySelector('#message_image'),addEventListener('change', function(e){
-    const image_content = document.querySelector('img');
+  const image_content = document.querySelector('img');
     if (image_content){
       image_content.remove();
     };
@@ -8,6 +8,8 @@ document.addEventListener('DOMContentLoaded', function(){
     const preview = e.target.files[0];
     const blob = window.URL.createObjectURL(preview);
     const html = `<img src="${blob}">`;
+    const inputHTML = `<input type='file' name='message[images][]' id="message_images">`;
     document.querySelector('form').insertAdjacentHTML('afterend' , html);
+    document.getElementById('new_message').insertAdjacentHTML('beforeend', inputHTML);
   });
 });

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,4 +1,4 @@
 class Message < ApplicationRecord
-  has_one_attached :image
+  has_many_attached :images
   validates :content, presence: true
 end

--- a/app/views/messages/_form.html.erb
+++ b/app/views/messages/_form.html.erb
@@ -1,3 +1,6 @@
+<label for='' id='click-upload'>
+  ここをクリックして画像をアップロード
+</label>
 <%= form_with model: @message, id: 'new_message', local: true do |f| %>
   <%= f.text_field :content, placeholder: 'type a message' %>
   <%= f.file_field :images, name: 'message[images][]' %>

--- a/app/views/messages/_form.html.erb
+++ b/app/views/messages/_form.html.erb
@@ -1,5 +1,5 @@
 <%= form_with model: @message, id: 'new_message', local: true do |f| %>
   <%= f.text_field :content, placeholder: 'type a message' %>
-  <%= f.file_field :image %>
+  <%= f.file_field :images, name: 'message[images][]' %>
   <%= f.submit '送信' %>
 <% end%>

--- a/app/views/messages/_form.html.erb
+++ b/app/views/messages/_form.html.erb
@@ -3,6 +3,6 @@
 </label>
 <%= form_with model: @message, id: 'new_message', local: true do |f| %>
   <%= f.text_field :content, placeholder: 'type a message' %>
-  <%= f.file_field :images, name: 'message[images][]' %>
+  <%= f.file_field :images, name: 'message[images][]', data:{index: 0} %>
   <%= f.submit '送信' %>
 <% end%>

--- a/app/views/messages/index.html.erb
+++ b/app/views/messages/index.html.erb
@@ -2,6 +2,8 @@
 <h3><%= link_to '新規投稿', new_message_path%></h3>
 <% @messages.each do |message| %>
   <%= message.content%>
-  <%= image_tag message.image if message.image.present? %>
+  <% message.images.each do |image| %>
+    <%= image_tag image %>
+  <% end %>
   <%= link_to '編集', edit_message_path(message.id)%>
 <% end %>


### PR DESCRIPTION
# 概要
複数枚画像投稿を実装しようのQC
# 実装内容
## 複数枚画像投稿の実装
### 新しく学ぶ知識
- has_many_attached

### 作業箇所
- アソシエーションを変更しましょう
- name属性を設定しましょう
- ストロングパラメーターを編集しましょう
- input要素を追加しましょう
- 保存した画像を表示させましょう
